### PR TITLE
메인으로 가는 메뉴 중복으로 인한 제거

### DIFF
--- a/mybook/book/templates/base.html
+++ b/mybook/book/templates/base.html
@@ -140,9 +140,6 @@ a:hover {
   <div class="collapse navbar-collapse" id="navbarSupportedContent">
     <ul class="navbar-nav mr-auto">
       <li class="nav-item">
-        <a class="nav-link" href="{% url 'index' %}">메인</a>
-      </li>
-      <li class="nav-item">
         <a class="nav-link" href="{% url 'book-list' %}">내 서재</a>
       </li>
       <li class="nav-item">


### PR DESCRIPTION
가장 좌측에 `My Book` 클릭으로만 메인메뉴로 이동하도록 
`메인` 메뉴 제거

### 수정 및 확인사항 
- `메인` 메뉴가 제거되었는지 확인